### PR TITLE
openvidu-mvc-java: change to autoplay=autoplay

### DIFF
--- a/openvidu-mvc-java/src/main/resources/templates/session.html
+++ b/openvidu-mvc-java/src/main/resources/templates/session.html
@@ -50,7 +50,7 @@
 				<div id="main-video" class="col-md-6">
 					<p class="nickName"></p>
 					<p class="userName"></p>
-					<video autoplay playsinline="true"></video>
+					<video autoplay="autoplay" playsinline="true"></video>
 				</div>
 				<div id="video-container" class="col-md-6"></div>
 			</div>


### PR DESCRIPTION
I got a White Label Error Page when I moved to `https://server-ip:5000/session`.  
This is the error page log
```
Whitelabel Error page
There was an unexpected error(type=Internal Server Error, status=500).
Exception parsing document: template="session", line=53 - column 22
```
And, This is server log.
```
org.xml.sax.SAXParseException: Attribute name "autoplay" associated with an element the "video" must be followed by the ' = ' character.
```

I looked at the line 53 in `src/resources/templates/session.html` 
```
<video autoplay playsinline="true"></video>
```
Thymeleaf could not parse `autoplay`. And I changed to `autoplay="autoplay"`.

It's worked. I think this problem caused by thymeleaf parsing.

Additional, I found solution how to change thymeleaf parsing mode. 
https://www.google.com/search?client=ubuntu&channel=fs&q=thymeleaf+legacyhtml5&ie=utf-8&oe=utf-8

Sorry for my poor English.