### PR TITLE
openvidu-js-java: plugin springloaded version fix

### DIFF
--- a/openvidu-js-java/pom.xml
+++ b/openvidu-js-java/pom.xml
@@ -37,7 +37,7 @@
 					<dependency>
 						<groupId>org.springframework</groupId>
 						<artifactId>springloaded</artifactId>
-						<version>2.1.2.RELEASE</version>
+						<version>1.2.8.RELEASE</version>
 					</dependency>
 				</dependencies>
 			</plugin>


### PR DESCRIPTION
I started `openvidu-js-java` with maven. I got this error. Problem was `springloaded` version. 
I fixed the version by refering to `openvidu-recording-java plugin springloaded version fix` commit.

```
[INFO] --- spring-boot-maven-plugin:2.1.2.RELEASE:repackage (repackage) @ openvidu-js-java ---
[WARNING] The POM for org.springframework:springloaded:jar:2.1.2.RELEASE is missing, no dependency information available
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  5.561 s
[INFO] Finished at: 2019-02-21T17:16:58+09:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.springframework.boot:spring-boot-maven-plugin:2.1.2.RELEASE:repackage (repackage) on project openvidu-js-java: Execution repackage of goal org.springframework.boot:spring-boot-maven-plugin:2.1.2.RELEASE:repackage failed: Plugin org.springframework.boot:spring-boot-maven-plugin:2.1.2.RELEASE or one of its dependencies could not be resolved: Failure to find org.springframework:
springloaded:jar:2.1.2.RELEASE in https://repo.maven.apache.org/maven2 was cached in the local repository, resolution will not be reattempted until the update interval of central has elapsed or updates are forced -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginResolutionException
```