### PR TITLE
insecure-vue: fix form submit on desktop safari

### DIFF
--- a/openvidu-insecure-vue/src/App.vue
+++ b/openvidu-insecure-vue/src/App.vue
@@ -4,7 +4,7 @@
 			<div id="img-div"><img src="resources/images/openvidu_grey_bg_transp_cropped.png" /></div>
 			<div id="join-dialog" class="jumbotron vertical-center">
 				<h1>Join a video session</h1>
-				<form class="form-group" @submit="joinSession">
+				<div class="form-group">
 					<p>
 						<label>Participant</label>
 						<input v-model="myUserName" class="form-control" type="text" required>
@@ -14,9 +14,9 @@
 						<input v-model="mySessionId" class="form-control" type="text" required>
 					</p>
 					<p class="text-center">
-						<input class="btn btn-lg btn-success" type="submit" name="commit" value="Join!">
+						<button class="btn btn-lg btn-success" @click="joinSession()">Join!</button>
 					</p>
-				</form>
+				</div>
 			</div>
 		</div>
 


### PR DESCRIPTION
Clicking the join button caused the form to actually submit on desktop safari (13.1.1).

This PR removes the html form and starts the room join on button click.