### PR TITLE
Fixed an attempt to publish video after failure to set the local desc…

### DIFF
--- a/openvidu-android/app/src/main/java/io/openvidu/openvidu_android/openvidu/Session.java
+++ b/openvidu-android/app/src/main/java/io/openvidu/openvidu_android/openvidu/Session.java
@@ -172,8 +172,22 @@ public class Session {
             public void onCreateSuccess(SessionDescription sessionDescription) {
                 super.onCreateSuccess(sessionDescription);
                 Log.i("createOffer SUCCESS", sessionDescription.toString());
-                localParticipant.getPeerConnection().setLocalDescription(new CustomSdpObserver("createOffer_setLocalDescription"), sessionDescription);
-                websocket.publishVideo(sessionDescription);
+
+                localParticipant.getPeerConnection().setLocalDescription(
+                        new CustomSdpObserver("createOffer_setLocalDescription") {
+                            @Override
+                            public void onSetSuccess() {
+                                super.onSetSuccess();
+                                websocket.publishVideo(sessionDescription);
+                            }
+
+                            @Override
+                            public void onSetFailure(String s) {
+                                super.onCreateFailure(s);
+                                Log.e("setLocalDescription ERROR", s);
+                            }
+                        },
+                        sessionDescription);
             }
 
             @Override


### PR DESCRIPTION
When preparing to publish a video stream from an Android client app to OpenVidu session, it is possible that creating video offer succeeds but then setting it as the local description fails.

An example: Android client is configured to use a hardware video encoder, but a particular device does not have one. As a result, SDP description is created without some necessary video elements, and setting it as the local description fails at runtime.

The original code did not check the result of setting a local description before it went on to attempt publishing video. This resulted to breaking the whole OpenVidu session with rather severe consequences:
- various errors in server and client logs
- every participant's video streams stuck
- the session cannot be properly closed (it becomes a ghost session)

This simple fix checks if setting the local description succeeds, and only then attempts to publish video stream.

While this demo application does not configure HW encoder in use, other developers will use it as a basis for their apps. In addition, there can be other reasons why setting local description may fail. Hence, it should be checked.