### PR TITLE
openvidu-android: Updated webrtc sdk 

### DIFF
--- a/openvidu-android/.idea/jarRepositories.xml
+++ b/openvidu-android/.idea/jarRepositories.xml
@@ -21,5 +21,10 @@
       <option name="name" value="Google" />
       <option name="url" value="https://dl.google.com/dl/android/maven2/" />
     </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven" />
+      <option name="name" value="maven" />
+      <option name="url" value="https://jitpack.io" />
+    </remote-repository>
   </component>
 </project>

--- a/openvidu-android/app/build.gradle
+++ b/openvidu-android/app/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     implementation 'com.jakewharton:butterknife:10.2.0'
     implementation 'com.squareup.okhttp3:okhttp:4.2.0'
     implementation 'com.neovisionaries:nv-websocket-client:2.9'
-    implementation 'org.webrtc:google-webrtc:1.0.32006'
+    implementation 'com.github.webrtc-sdk:android:104.5112.03'
     annotationProcessor 'com.jakewharton:butterknife-compiler:10.2.0'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.4.0'

--- a/openvidu-android/app/src/main/java/io/openvidu/openvidu_android/openvidu/Session.java
+++ b/openvidu-android/app/src/main/java/io/openvidu/openvidu_android/openvidu/Session.java
@@ -89,7 +89,6 @@ public class Session {
         config.continualGatheringPolicy =
                 PeerConnection.ContinualGatheringPolicy.GATHER_CONTINUALLY;
         config.keyType = PeerConnection.KeyType.ECDSA;
-        config.enableDtlsSrtp = true;
         config.sdpSemantics = PeerConnection.SdpSemantics.UNIFIED_PLAN;
 
         PeerConnection peerConnection = peerConnectionFactory.createPeerConnection(config, new CustomPeerConnectionObserver("local") {
@@ -136,7 +135,6 @@ public class Session {
         config.continualGatheringPolicy =
                 PeerConnection.ContinualGatheringPolicy.GATHER_CONTINUALLY;
         config.keyType = PeerConnection.KeyType.ECDSA;
-        config.enableDtlsSrtp = true;
         config.sdpSemantics = PeerConnection.SdpSemantics.UNIFIED_PLAN;
 
         PeerConnection peerConnection = peerConnectionFactory.createPeerConnection(config, new CustomPeerConnectionObserver("remotePeerCreation") {

--- a/openvidu-android/build.gradle
+++ b/openvidu-android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath 'com.android.tools.build:gradle:7.2.2'
         
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -18,7 +18,9 @@ allprojects {
     repositories {
         google()
         jcenter()
-        
+        maven { url 'https://jitpack.io' }
+
+
     }
 }
 


### PR DESCRIPTION
The official Android WebRTC SKD library, supported by Google, is  not longer maintained and it is deprecated. 

This PR updates the WebRTC SDK using  the CloudWebRTC repository (https://github.com/webrtc-sdk/android)  with the aim of having an updated code and avoid security vulnerabilities 
