### PR TITLE
Pin GitHub Actions to specific commit SHAs and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/e2e-components-angular-tutorials.yml
+++ b/.github/workflows/e2e-components-angular-tutorials.yml
@@ -22,14 +22,14 @@ jobs:
       package_filename: ${{ steps.build.outputs.package_filename }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
       - name: Build OpenVidu Components Angular
         id: build
-        uses: OpenVidu/actions/build-openvidu-components-angular@main
+        uses: OpenVidu/actions/build-openvidu-components-angular@35d136377813cf9b0b23d12d16d57864ccf3a8c2 # v1.0.2
 
   build_and_start_tutorials:
     runs-on: ubuntu-latest
@@ -38,17 +38,17 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '22'
 
     # Download artifact if built from source - place it in the parent directory
     - name: Download OpenVidu Components Angular package
       if: needs.build_components.result == 'success'
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: ${{ needs.build_components.outputs.artifact_name }}
         path: './openvidu-components-angular'
@@ -71,22 +71,22 @@ jobs:
     if: always() && (needs.build_components.result == 'success' || needs.build_components.result == 'skipped')
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
 
       # Download artifact if built from source
       - name: Download OpenVidu Components Angular package
         if: needs.build_components.result == 'success'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
             name: ${{ needs.build_components.outputs.artifact_name }}
             path: './openvidu-components-angular/openvidu-demo-app'
 
       - name: Setup OpenVidu Local Deployment
-        uses: OpenVidu/actions/start-openvidu-local-deployment@main
+        uses: OpenVidu/actions/start-openvidu-local-deployment@35d136377813cf9b0b23d12d16d57864ccf3a8c2 # v1.0.2
         with:
           ref-openvidu-local-deployment: "development"
           openvidu-edition: "community"


### PR DESCRIPTION
## Summary

- Add Dependabot configuration for weekly GitHub Actions dependency updates
- Pin all action references to immutable commit SHAs instead of mutable tags (e.g. `@v4`, `@main`)
- Affected actions: `actions/checkout`, `actions/setup-node`, `actions/download-artifact`, `OpenVidu/actions/build-openvidu-components-angular`, `OpenVidu/actions/start-openvidu-local-deployment`

## Why

Pinning to commit SHAs prevents supply chain attacks where a tag could be moved to point to malicious code. This is a [GitHub security best practice](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

Dependabot will keep the pinned SHAs up to date automatically.