### PR TITLE
chore: update OpenVidu/actions to v1.0.9

### DIFF
--- a/.github/workflows/e2e-components-angular-tutorials.yml
+++ b/.github/workflows/e2e-components-angular-tutorials.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: '22'
       - name: Build OpenVidu Components Angular
         id: build
-        uses: OpenVidu/actions/build-openvidu-components-angular@9a2f61e73052475bd4572ce2f3a574476a37eae5 # v1.0.8
+        uses: OpenVidu/actions/build-openvidu-components-angular@f280a774e4adcf3733147d1babe9c16c57993a2d # v1.0.9
 
   build_and_start_tutorials:
     runs-on: ubuntu-latest
@@ -86,7 +86,7 @@ jobs:
             path: './openvidu-components-angular/openvidu-demo-app'
 
       - name: Setup OpenVidu Local Deployment
-        uses: OpenVidu/actions/start-openvidu-local-deployment@9a2f61e73052475bd4572ce2f3a574476a37eae5 # v1.0.8
+        uses: OpenVidu/actions/start-openvidu-local-deployment@f280a774e4adcf3733147d1babe9c16c57993a2d # v1.0.9
         with:
           ref-openvidu-local-deployment: "development"
           openvidu-edition: "community"


### PR DESCRIPTION
Updates pinned references of `OpenVidu/actions` to `v1.0.9`.

Auto-generated by the [update-pinned-actions](https://github.com/OpenVidu/actions/actions/workflows/update-pinned-actions.yml) workflow.