### PR TITLE
chore: update OpenVidu/actions to v1.0.18

### DIFF
--- a/.github/workflows/e2e-components-angular-tutorials.yml
+++ b/.github/workflows/e2e-components-angular-tutorials.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Build OpenVidu Components Angular
         id: build
-        uses: OpenVidu/actions/build-openvidu-components-angular@0125dee363f943e399bf576e8e4c162fafcc5bdd # v1.0.16
+        uses: OpenVidu/actions/build-openvidu-components-angular@e585b0ac266d7afffc6cba105b380ad6a477a4c0 # v1.0.18
 
   build_and_start_tutorials:
     runs-on: ubuntu-latest
@@ -47,7 +47,7 @@ jobs:
         node-version: '22'
 
     - name: Install safe-chain
-      uses: OpenVidu/actions/install-safe-chain@0125dee363f943e399bf576e8e4c162fafcc5bdd # v1.0.16
+      uses: OpenVidu/actions/install-safe-chain@e585b0ac266d7afffc6cba105b380ad6a477a4c0 # v1.0.18
 
     # Download artifact if built from source - place it in the parent directory
     - name: Download OpenVidu Components Angular package
@@ -82,7 +82,7 @@ jobs:
           node-version: '22'
 
       - name: Install safe-chain
-        uses: OpenVidu/actions/install-safe-chain@0125dee363f943e399bf576e8e4c162fafcc5bdd # v1.0.16
+        uses: OpenVidu/actions/install-safe-chain@e585b0ac266d7afffc6cba105b380ad6a477a4c0 # v1.0.18
 
       # Download artifact if built from source
       - name: Download OpenVidu Components Angular package
@@ -93,7 +93,7 @@ jobs:
             path: './openvidu-components-angular/openvidu-demo-app'
 
       - name: Setup OpenVidu Local Deployment
-        uses: OpenVidu/actions/start-openvidu-local-deployment@0125dee363f943e399bf576e8e4c162fafcc5bdd # v1.0.16
+        uses: OpenVidu/actions/start-openvidu-local-deployment@e585b0ac266d7afffc6cba105b380ad6a477a4c0 # v1.0.18
         with:
           ref-openvidu-local-deployment: "development"
           openvidu-edition: "community"


### PR DESCRIPTION
Updates pinned references of `OpenVidu/actions` to `v1.0.18`.

Auto-generated by the [update-pinned-actions](https://github.com/OpenVidu/actions/actions/workflows/update-pinned-actions.yml) workflow.